### PR TITLE
Minor improvements

### DIFF
--- a/src/System/Console/Shell/RunShell.hs
+++ b/src/System/Console/Shell/RunShell.hs
@@ -217,9 +217,11 @@ shellLoop desc backend iss = loop
    bst = backendState iss
 
    loop st = do
-        flushOutput backend bst
+     flushOutput backend bst
+     
+     runSh st (outputString backend bst) (beforePrompt desc) >>= loop' . fst
 
-        runSh st (outputString backend bst) (beforePrompt desc)
+   loop' st = do
         setAttemptedCompletionFunction backend bst
               (completionFunction desc backend bst st)
 


### PR DESCRIPTION
- Allow modification of shell-state during `beforePrompt`-hook
- Handle tab-completion for suggestions containing `breakChars` slightly more gracefully (though this solution seems still very fragile to me since I didn´t bother to actually inspect Shellacs parser)
