### PR TITLE
Fix compatibility with ghc 8.4

### DIFF
--- a/src/System/Console/Shell/Commands.hs
+++ b/src/System/Console/Shell/Commands.hs
@@ -21,6 +21,7 @@ module System.Console.Shell.Commands
 , commandsRegex
 ) where
 
+import Prelude hiding ((<>))
 import System.Console.Shell.Types
 import System.Console.Shell.PPrint
 import System.Console.Shell.Regex

--- a/src/System/Console/Shell/PPrint.hs
+++ b/src/System/Console/Shell/PPrint.hs
@@ -47,7 +47,7 @@ module System.Console.Shell.PPrint
         , displayS, displayIO
         ) where
 
-import Prelude hiding ( (<|>), (<$>) )
+import Prelude hiding ( (<|>), (<$>), (<>) )
 import System.IO      (Handle,hPutStr,hPutChar,stdout)
 
 infixr 5 </>,<//>,<$>,<$$>


### PR DESCRIPTION
Hide <> from Prelude in PPrint.hs and Commands.hs